### PR TITLE
Add override field to variables in StateVariableDeclaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -120,7 +120,7 @@ export interface InheritanceSpecifier extends BaseASTNode {
 }
 export interface StateVariableDeclaration extends BaseASTNode {
   type: 'StateVariableDeclaration';
-  variables: VariableDeclaration[];
+  variables: VariableDeclarationWithOverride[];
   initialValue?: Expression;
 }
 export interface UsingForDeclaration extends BaseASTNode {
@@ -178,6 +178,9 @@ export interface VariableDeclaration extends BaseASTNode {
   storageLocation?: string;
   expression?: Expression;
   visibility?: 'public' | 'private' | 'internal' | 'default';
+}
+export interface VariableDeclarationWithOverride extends VariableDeclaration {
+  override: null | UserDefinedTypeName[];
 }
 export interface UserDefinedTypeName extends BaseASTNode {
   type: 'UserDefinedTypeName';

--- a/src/ASTBuilder.js
+++ b/src/ASTBuilder.js
@@ -869,6 +869,14 @@ const transformAST = {
       isDeclaredConst = true
     }
 
+    let override
+    const overrideSpecifier = ctx.overrideSpecifier()
+    if (overrideSpecifier.length === 0) {
+      override = null
+    } else {
+      override = this.visit(overrideSpecifier[0].userDefinedTypeName())
+    }
+
     const decl = this.createNode(
       {
         type: 'VariableDeclaration',
@@ -878,14 +886,15 @@ const transformAST = {
         visibility,
         isStateVar: true,
         isDeclaredConst,
-        isIndexed: false
+        isIndexed: false,
+        override,
       },
       iden
     )
 
     return {
       variables: [decl],
-      initialValue: expression
+      initialValue: expression,
     }
   },
 

--- a/test/ast.js
+++ b/test/ast.js
@@ -324,6 +324,30 @@ describe('AST', () => {
     })
   })
 
+  it('StateVariableDeclaration with override', () => {
+    var ast = parseNode("uint public override foo;")
+    assert.deepEqual(ast, {
+      "type": "StateVariableDeclaration",
+      "variables": [
+        {
+          "type": "VariableDeclaration",
+          "typeName": {
+            "type": "ElementaryTypeName",
+            "name": "uint"
+          },
+          "name": "foo",
+          "expression": null,
+          "visibility": "public",
+          "override": [],
+          "isStateVar": true,
+          "isDeclaredConst": false,
+          "isIndexed": false
+        }
+      ],
+      "initialValue": null
+    })
+  })
+
   it('FunctionDefinition with one explicit override', () => {
     var ast = parseNode("function foo() public override(Base) {}")
     assert.deepEqual(ast, {
@@ -346,6 +370,33 @@ describe('AST', () => {
       "isReceiveEther": false,
       "isVirtual": false,
       "stateMutability": null,
+    })
+  })
+
+  it('StateVariableDeclaration with one explicit override', () => {
+    var ast = parseNode("uint public override(Base) foo;")
+    assert.deepEqual(ast, {
+      "type": "StateVariableDeclaration",
+      "variables": [
+        {
+          "type": "VariableDeclaration",
+          "typeName": {
+            "type": "ElementaryTypeName",
+            "name": "uint"
+          },
+          "name": "foo",
+          "expression": null,
+          "visibility": "public",
+          "override": [{
+            "type": "UserDefinedTypeName",
+            "namePath": "Base"
+          }],
+          "isStateVar": true,
+          "isDeclaredConst": false,
+          "isIndexed": false
+        }
+      ],
+      "initialValue": null
     })
   })
 
@@ -374,6 +425,36 @@ describe('AST', () => {
       "isReceiveEther": false,
       "isVirtual": false,
       "stateMutability": null,
+    })
+  })
+
+  it('StateVariableDeclaration with two overrides', () => {
+    var ast = parseNode("uint public override(Base1, Base2) foo;")
+    assert.deepEqual(ast, {
+      "type": "StateVariableDeclaration",
+      "variables": [
+        {
+          "type": "VariableDeclaration",
+          "typeName": {
+            "type": "ElementaryTypeName",
+            "name": "uint"
+          },
+          "name": "foo",
+          "expression": null,
+          "visibility": "public",
+          "override": [{
+            "type": "UserDefinedTypeName",
+            "namePath": "Base1"
+          }, {
+            "type": "UserDefinedTypeName",
+            "namePath": "Base2"
+          }],
+          "isStateVar": true,
+          "isDeclaredConst": false,
+          "isIndexed": false
+        }
+      ],
+      "initialValue": null
     })
   })
 
@@ -736,7 +817,8 @@ describe('AST', () => {
       "visibility": "default",
       "isStateVar": true,
       "isDeclaredConst": false,
-      "isIndexed": false
+      "isIndexed": false,
+      "override": null,
     })
   })
 
@@ -1217,6 +1299,7 @@ describe('AST', () => {
           "name": "a",
           "expression": null,
           "visibility": "default",
+          "override": null,
           "isStateVar": true,
           "isDeclaredConst": false,
           "isIndexed": false


### PR DESCRIPTION
Closes #9 

As with `FunctionDefinition`, the `override` field in the variables* in `StateVariableDeclaration` is:

- `null` if there's no override
- `[]` if there's just a simple `override`
- `[{}, {}, ...]` if it's `override(Base1, Base2, ...)` (see the typescript declaration to see how it's formed).