### PR TITLE
Change node structure for NameValueList

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -85,7 +85,8 @@ export type ASTNodeTypeString =
   | 'HexNumber'
   | 'DecimalNumber'
   | 'MemberAccess'
-  | 'IndexAccess';
+  | 'IndexAccess'
+  | 'NameValueList';
 export interface BaseASTNode {
   type: ASTNodeTypeString;
   range?: [number, number];
@@ -441,6 +442,11 @@ export interface HexNumber extends BaseASTNode {
 export interface DecimalNumber extends BaseASTNode {
   type: 'DecimalNumber';
   value: string;
+}
+export interface NameValueList extends BaseASTNode {
+  type: 'NameValueList';
+  names: string[];
+  args: Expression[];
 }
 export type ASTNode =
   | SourceUnit

--- a/src/ASTBuilder.js
+++ b/src/ASTBuilder.js
@@ -832,16 +832,18 @@ const transformAST = {
   },
 
   NameValueList(ctx) {
-    const values = {}
+    const names = []
+    const args = []
 
     for (const nameValue of ctx.nameValue()) {
-      const name = toText(nameValue.identifier())
-      values[name]  =this.visit(nameValue.expression())
+      names.push(toText(nameValue.identifier()))
+      args.push(this.visit(nameValue.expression()))
     }
 
     return {
       type: 'NameValueList',
-      values,
+      names,
+      arguments: args,
     }
   },
 

--- a/test/ast.js
+++ b/test/ast.js
@@ -2014,13 +2014,12 @@ describe('AST', () => {
       "expression": {
         "arguments": {
           "type": "NameValueList",
-          "values": {
-            "value": {
-              "number": "1",
-              "subdenomination": null,
-              "type": "NumberLiteral"
-            }
-          }
+          "names": ["value"],
+          "arguments": [{
+            "number": "1",
+            "subdenomination": null,
+            "type": "NumberLiteral"
+          }],
         },
         "expression": {
           "expression": {
@@ -2042,18 +2041,18 @@ describe('AST', () => {
       "expression": {
         "arguments": {
           "type": "NameValueList",
-          "values": {
-            "value": {
+          "names": ["value", "gas"],
+          "arguments": [
+             {
               "number": "1",
               "subdenomination": null,
               "type": "NumberLiteral"
             },
-            "gas": {
+            {
               "number": "21000",
               "subdenomination": null,
               "type": "NumberLiteral"
-            }
-          }
+            }]
         },
         "expression": {
           "expression": {


### PR DESCRIPTION
In #3 I mentioned that I structured the `NameValueList` node in what for me was a more reasonable way. Now I understand a little better (but not 100%) why a similar node used a pair of arrays instead of an object: some things don't work when visiting the tree with the structure I proposed. So I changed it to a pair of arrays.

This is a breaking change, albeit of a short-lived interface, so this should be a major version change, but that seems overkill. So if no one is relying in the specific structure of `NameValueList` nodes I won't make a new major because of this (and I will try to be more careful with API changes -_-)

Tagging people relying on this parser: @naddison36 @cgewecke @alcuadrado @mattiaerre @Janther