### PR TITLE
Join version constraints with a space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
-  - "8"
+  - "10"
+
+script:
+  - npm run eslint
+  - npm test

--- a/src/ASTBuilder.js
+++ b/src/ASTBuilder.js
@@ -108,9 +108,16 @@ const transformAST = {
   },
 
   PragmaDirective(ctx) {
+    // this converts something like >= 0.5.0  <0.7.0
+    // in >=0.5.0 <0.7.0
+    const value = ctx
+      .pragmaValue()
+      .children[0].children.map(x => toText(x))
+      .join(" ")
+
     return {
       name: toText(ctx.pragmaName()),
-      value: toText(ctx.pragmaValue())
+      value
     }
   },
 

--- a/test/ast.js
+++ b/test/ast.js
@@ -79,7 +79,7 @@ describe('AST', () => {
     "~0.3.11",, "~1.3", "~10",
     "=0.0.1", "=0.6", "=1",
     "<=1.1.1", "<=11.11", "<=111",
-    "<0.5.11"]
+    "<0.5.11", ">=0.6.7 <0.7.0"]
   versions.forEach(function (version) {
     it("PragmaDirective " + version, function() {
       var ast = parser.parse("pragma solidity " + version + ";")


### PR DESCRIPTION
Before this change, the parser would take something like this:

```
pragma solidity >= 0.5.0 <0.7.0
```

and give the pragma value as `>=0.5.0<0.7.0`, which is an invalid range (at least to `node-semver`).

With this change, `>=0.5.0 <0.7.0` will be returned instead. Notice though that the space after `>=` was lost.