### PR TITLE
Handle fallback with argument and return value

### DIFF
--- a/src/ASTBuilder.ts
+++ b/src/ASTBuilder.ts
@@ -340,6 +340,15 @@ export class ASTBuilder
         isConstructor = true
         break
       case 'fallback':
+        parameters = ctx
+          .parameterList()
+          .parameter()
+          .map((x) => this.visit(x))
+        returnParameters =
+          ctxReturnParameters !== undefined
+            ? this.visitReturnParameters(ctxReturnParameters)
+            : null
+
         visibility = 'external'
         isFallback = true
         break

--- a/test/ast.ts
+++ b/test/ast.ts
@@ -488,6 +488,66 @@ describe('AST', () => {
     })
   })
 
+  it('FunctionDefinition fallback with argument and return value', () => {
+    const ast: any = parseNode(
+      'fallback (bytes calldata input) external returns (bytes memory output) {}'
+    )
+    assert.deepEqual(ast, {
+      type: 'FunctionDefinition',
+      name: null,
+      parameters: [
+        {
+          isIndexed: false,
+          isStateVar: false,
+          name: 'input',
+          identifier: {
+            type: 'Identifier',
+            name: 'input',
+          },
+          storageLocation: 'calldata',
+          type: 'VariableDeclaration',
+          typeName: {
+            name: 'bytes',
+            type: 'ElementaryTypeName',
+            stateMutability: null,
+          },
+          expression: null,
+        },
+      ],
+      returnParameters: [
+        {
+          isIndexed: false,
+          isStateVar: false,
+          name: 'output',
+          identifier: {
+            name: 'output',
+            type: 'Identifier',
+          },
+          storageLocation: 'memory',
+          type: 'VariableDeclaration',
+          typeName: {
+            name: 'bytes',
+            type: 'ElementaryTypeName',
+            stateMutability: null,
+          },
+          expression: null,
+        },
+      ],
+      body: {
+        type: 'Block',
+        statements: [],
+      },
+      visibility: 'external',
+      modifiers: [],
+      override: null,
+      isConstructor: false,
+      isFallback: true,
+      isReceiveEther: false,
+      isVirtual: false,
+      stateMutability: null,
+    })
+  })
+
   it('FunctionDefinition virtual receive', () => {
     const ast: any = parseNode('receive () external payable virtual {}')
     assert.deepEqual(ast, {

--- a/test/test.sol
+++ b/test/test.sol
@@ -785,3 +785,7 @@ library FixedMath {
 contract C {
   using L.Lib for uint;
 }
+
+contract FallbackWithArgs {
+  fallback (bytes calldata input) external payable returns (bytes memory output) {}
+}


### PR DESCRIPTION
Closes: #65

The parser doesn't handle the new fallback syntax introduced by [Solidity v0.7.6](https://github.com/ethereum/solidity/releases/tag/v0.7.6). 

