### PR TITLE
Add start/end index to loc for easier source printing

### DIFF
--- a/src/ASTBuilder.ts
+++ b/src/ASTBuilder.ts
@@ -12,10 +12,12 @@ interface SourceLocation {
   start: {
     line: number
     column: number
+    index: number
   }
   end: {
     line: number
     column: number
+    index: number
   }
 }
 
@@ -1970,12 +1972,16 @@ export class ASTBuilder
       start: {
         line: ctx.start.line,
         column: ctx.start.charPositionInLine,
+        index: ctx.start.startIndex,
       },
       end: {
         line: ctx.stop ? ctx.stop.line : ctx.start.line,
         column: ctx.stop
           ? ctx.stop.charPositionInLine
           : ctx.start.charPositionInLine,
+        index: ctx.stop
+          ? ctx.stop.stopIndex
+          : ctx.start.startIndex,
       },
     }
     return sourceLocation

--- a/test/index.ts
+++ b/test/index.ts
@@ -78,10 +78,12 @@ describe('#parse', function () {
         start: {
           line: 1,
           column: 0,
+          index: -1,
         },
         end: {
           line: 1,
           column: 0,
+          index: 0,
         },
       },
     })


### PR DESCRIPTION
This enables the following pattern:

```js
const input = `
    contract test {
        uint256 a;
        function f() {}
    }
`

var ast = parser.parse(input, { loc: true })

parser.visit(ast, {
  FunctionDefinition: function(node) {
    let source = input.substring(node.loc.start.index, node.loc.end.index + 1)

    //=> prints "function f() {}"
    console.log('Source code:', source)
  }
})
```