### PR TITLE
adding comments to the ASTNode type definition

### DIFF
--- a/src/ast-types.ts
+++ b/src/ast-types.ts
@@ -14,10 +14,32 @@ interface Location {
   }
 }
 
+export const commentTypes = ['BlockComment', 'LineComment'] as const
+
+export type CommentTypeString = typeof commentTypes[number]
+
+export interface BaseComment {
+  type: CommentTypeString
+  range?: [number, number]
+  loc?: Location
+  raw: string
+  value: string
+}
+
+export interface BlockComment extends BaseComment {
+  type: 'BlockComment'
+}
+export interface LineComment extends BaseComment {
+  type: 'LineComment'
+}
+
+export type Comment = BlockComment | LineComment
+
 export interface BaseASTNode {
   type: ASTNodeTypeString
   range?: [number, number]
   loc?: Location
+  comments?: Comment[]
 }
 
 export interface SourceUnit extends BaseASTNode {
@@ -116,7 +138,7 @@ export const astNodeTypes = [
   'CatchClause',
   'FileLevelConstant',
   'AssemblyMemberAccess',
-  'TypeDefinition'
+  'TypeDefinition',
 ] as const
 
 export type ASTNodeTypeString = typeof astNodeTypes[number]
@@ -156,7 +178,7 @@ export interface UsingForDeclaration extends BaseASTNode {
   // will be the defined operator, or null if it's just an attached function
   operators: Array<string | null>
   libraryName: string | null
-  isGlobal: boolean;
+  isGlobal: boolean
 }
 export interface StructDefinition extends BaseASTNode {
   type: 'StructDefinition'
@@ -736,7 +758,8 @@ function checkTypes() {
   assignAstNodeTypeStringExit = astVisitorEnterKeyExit
   assignAstNodeTypeStringExit = astVisitorExitKey
 
-  let assignAstVisitorEnterKeyExit: `${keyof ASTVisitorEnter}:exit` = astNodeTypeExit
+  let assignAstVisitorEnterKeyExit: `${keyof ASTVisitorEnter}:exit` =
+    astNodeTypeExit
   assignAstVisitorEnterKeyExit = astNodeTypeStringExit
   assignAstVisitorEnterKeyExit = astVisitorExitKey
 

--- a/src/ast-types.ts
+++ b/src/ast-types.ts
@@ -14,9 +14,7 @@ interface Location {
   }
 }
 
-export const commentTypes = ['BlockComment', 'LineComment'] as const
-
-export type CommentTypeString = typeof commentTypes[number]
+export type CommentTypeString = 'BlockComment' | 'LineComment'
 
 export interface BaseComment {
   type: CommentTypeString


### PR DESCRIPTION
Hi,
I'd like to move `prettier-plugin-solidity` to typescript and I want to use the types you already made for the AST nodes, but they are missing the comments, so I added them here.

Thought it was better than replicating everything over there, even if this project doesn't deal with comments.